### PR TITLE
Return 500 error on navigation timeout

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -170,7 +170,8 @@ export class Renderer {
       if (this.config.closeBrowser) {
         await this.browser.close();
       }
-      return { status: 400, customHeaders: new Map(), content: '' };
+      // 400エラーを返すとインデックスを削除されるリスクがあるので、500エラーを返す
+      return { status: 500, customHeaders: new Map(), content: '' };
     }
 
     // Disable access to compute metadata. See


### PR DESCRIPTION
> URLs that are already indexed and return a 4xx status code are removed from the index.

https://developers.google.com/search/docs/crawling-indexing/http-network-errors

400エラーを返すとインデックスを削除される可能性があるので、500エラーを返す