### PR TITLE
Use page.close() before returning 500

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -248,6 +248,11 @@ export class Renderer {
     // Serialize page.
     const result = (await page.content()) as string;
 
+    await page.close();
+    if (this.config.closeBrowser) {
+      await this.browser.close();
+    }
+
     // レストランページでタイトルが初期状態 `AutoReserve` のままのとき rendering がミスってるので、500エラーを返す
     if ((/\/[a-z]{2}(-[a-z]{2})?\/restaurants\/[a-zA-Z0-9]+$/).test(parsedUrl.pathname ?? '') && statusCode === 200 && result.includes('<title>AutoReserve</title>')) {
       return {
@@ -255,11 +260,6 @@ export class Renderer {
         customHeaders: new Map(),
         content: ''
       }
-    }
-
-    await page.close();
-    if (this.config.closeBrowser) {
-      await this.browser.close();
     }
 
     const headers = customHeaders


### PR DESCRIPTION
latency やCPU使用率が上がる対策として入れる
<img width="690" alt="image" src="https://github.com/hello-ai/rendertron/assets/116057/0ed88c76-bbf9-4da5-88f6-e6cfe2b65d07">
